### PR TITLE
Adds a Workflow that wraps wordcount

### DIFF
--- a/wordcount-workflow-packed.cwl
+++ b/wordcount-workflow-packed.cwl
@@ -1,0 +1,67 @@
+{
+    "$graph": [
+        {
+            "class": "Workflow",
+            "inputs": [
+                {
+                    "type": "File",
+                    "id": "#main/somefile"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "File",
+                    "outputSource": "#main/wc/output",
+                    "id": "#main/output"
+                }
+            ],
+            "steps": [
+                {
+                    "run": "#wordcount.cwl",
+                    "in": [
+                        {
+                            "source": "#main/somefile",
+                            "id": "#main/wc/somefile"
+                        }
+                    ],
+                    "out": [
+                        "#main/wc/output"
+                    ],
+                    "id": "#main/wc"
+                }
+            ],
+            "id": "#main"
+        },
+        {
+            "class": "CommandLineTool",
+            "baseCommand": "wc",
+            "requirements": [
+                {
+                    "class": "InlineJavascriptRequirement"
+                }
+            ],
+            "stdout": "output.txt",
+            "label": "wc pairs of files",
+            "doc": "wc pairs",
+            "inputs": [
+                {
+                    "type": "File",
+                    "id": "#wordcount.cwl/somefile"
+                }
+            ],
+            "arguments": [
+                {
+                    "valueFrom": "$(inputs.somefile.path)"
+                }
+            ],
+            "outputs": [
+                {
+                    "type": "stdout",
+                    "id": "#wordcount.cwl/output"
+                }
+            ],
+            "id": "#wordcount.cwl"
+        }
+    ],
+    "cwlVersion": "v1.0"
+}

--- a/wordcount-workflow-packed.cwl
+++ b/wordcount-workflow-packed.cwl
@@ -2,6 +2,7 @@
     "$graph": [
         {
             "class": "Workflow",
+            "doc": "word count",
             "inputs": [
                 {
                     "type": "File",

--- a/wordcount-workflow.cwl
+++ b/wordcount-workflow.cwl
@@ -1,6 +1,6 @@
 cwlVersion: v1.0
 class: Workflow
-
+doc: word count
 inputs:
   somefile: File
 

--- a/wordcount-workflow.cwl
+++ b/wordcount-workflow.cwl
@@ -1,0 +1,17 @@
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  somefile: File
+
+outputs:
+  output:
+    type: File
+    outputSource: wc/output
+
+steps:
+  wc:
+    run: wordcount.cwl
+    in:
+      somefile: somefile
+    out: [output]


### PR DESCRIPTION
In testing bespin-cli and lando changes, I needed a simple `class: Workflow` document in packed and non-packed versions. This change adds that to this repo for the wordcount tool.

See also https://github.com/Duke-GCB/calrissian/issues/50